### PR TITLE
chore: require Go 1.25 minimum

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/adder-library-starter-kit
 
-go 1.24.0
+go 1.25.7
 
-toolchain go1.24.1
+toolchain go1.25.8
 
 require (
 	github.com/blinklabs-io/adder v0.39.1


### PR DESCRIPTION
## Summary

Go 1.24 is end-of-life. This bumps the module to a **Go 1.25 minimum** and aligns CI tool versions with the rest of the Blink Labs Go repos:

- `go.mod`: `go 1.24.0` → `go 1.25.7`, `toolchain go1.24.1` → `toolchain go1.25.8`
- `golangci-lint.yml`, `nilaway.yml`: `1.25.x` → `1.26.x`

There is no `go-test` workflow / no tests in this starter kit, so the "test on 1.25 and 1.26" matrix is not applicable here.

## Verification

`go build ./...` and `go vet ./...` pass locally on Go 1.26; `gofmt -l` and `golangci-lint run ./...` (0 issues) are clean. `go.sum` is unchanged.

Part of the org-wide Go 1.25 upgrade (blinklabs-io/issues#120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require Go 1.25+ and update CI linters to run on Go 1.26.x, dropping EOL 1.24 and aligning with other Blink Labs Go repos.

- **Dependencies**
  - `go.mod`: `go 1.25.7`, `toolchain go1.25.8`

<sup>Written for commit 1a0c361490a98451fb1ee6ea3d368bfc5cff993a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder-library-starter-kit/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

